### PR TITLE
Use dns.setServers - io.js or node 0.12 required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,3 @@ language: node_js
 node_js:
   - 'iojs'
   - '0.12'
-  - '0.10'

--- a/cli.js
+++ b/cli.js
@@ -4,7 +4,6 @@ var logSymbols = require('log-symbols');
 var pkg = require('./package.json');
 var isOnline = require('./');
 var argv = process.argv.slice(2);
-var input = argv[0];
 
 function help() {
 	console.log([

--- a/index.js
+++ b/index.js
@@ -1,68 +1,13 @@
 'use strict';
-var dns = require('native-dns');
-var net = require('net');
-var eachAsync = require('each-async');
-var onetime = require('onetime');
+var dns = require('dns');
 var roots = require('root-hints')('A');
 
-var timeout = 1000;
-var domains = [
-	'www.google.com',
-	'www.cloudflare.com',
-	'www.baidu.com',
-	'www.yandex.ru'
-];
-
 module.exports = function (cb) {
-	cb = onetime(cb);
+    // set dns to query the root servers
+    dns.setServers(roots);
 
-	// Pick a random root server to query
-	var server = roots[Math.floor(Math.random() * roots.length)];
-
-	// Set up a DNS request that requests the authoritative information for
-	// the 'com' zone
-	var req = dns.Request({
-		question: dns.Question({
-			name: 'com',
-			type: 'NS'
-		}),
-		server: {
-			address: server
-		},
-		timeout: timeout
-	});
-
-	req.on('timeout', function () {
-		// We ran into the timeout, we're offline with high confidence
-		cb(null, false);
-	});
-
-	req.on('message', function (err, answer) {
-		if (answer.authority.length && answer._socket.address === server) {
-			// We got an answer and the source matches the queried server,
-			// we're online with high confidence
-			cb(null, true);
-		} else {
-			// Either DNS intercepting is in place or the response in mangled,
-			// try connecting to our domains on port 80, and if one handshake
-			// succeeds, we're definitely online
-			eachAsync(domains, function (domain, i, next) {
-				var socket = new net.Socket();
-				socket.setTimeout(timeout);
-				socket.on('error', function () {
-					socket.destroy();
-					next();
-				});
-				socket.connect(80, domain, function () {
-					cb(null, true);
-					socket.end();
-					next(new Error()); // skip to end
-				});
-			}, function () {
-				cb(null, false);
-			});
-		}
-	});
-
-	req.send();
+    // request the authoritative records for the root zone
+    dns.resolveNs('', function (err, servers) {
+        cb(null, Boolean(!err && servers.length));
+    });
 };

--- a/index.js
+++ b/index.js
@@ -1,13 +1,47 @@
 'use strict';
 var dns = require('dns');
+var net = require('net');
+var eachAsync = require('each-async');
+var onetime = require('onetime');
 var roots = require('root-hints')('A');
 
-module.exports = function (cb) {
-    // set dns to query the root servers
-    dns.setServers(roots);
+var timeout = 1000;
+var domains = [
+	'www.google.com',
+	'www.cloudflare.com',
+	'www.baidu.com',
+	'www.yandex.ru'
+];
 
-    // request the authoritative records for the root zone
-    dns.resolveNs('', function (err, servers) {
-        cb(null, Boolean(!err && servers.length));
-    });
+module.exports = function (cb) {
+	cb = onetime(cb);
+
+	// set dns to query the root servers
+	dns.setServers(roots);
+
+	// request the authoritative records for the root zone
+	dns.resolveNs('', function (err, servers) {
+		if (!err && servers.length) {
+			cb(null, true);
+		} else {
+			// dns query either failed or returned no result,
+			// try connecting to our domains in parallel
+			eachAsync(domains, function (domain, i, next) {
+				var socket = new net.Socket();
+				socket.unref();
+				socket.setTimeout(timeout, next);
+				socket.on('error', function () {
+					socket.destroy();
+					next();
+				});
+				socket.connect(80, domain, function () {
+					cb(null, true);
+					socket.end();
+					next(new Error()); // skip to end
+				});
+			}, function () {
+				cb(null, false);
+			});
+		}
+	});
 };

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "detect"
   ],
   "dependencies": {
-    "each-async": "^1.1.1",
+    "each-async": "^1.1.0",
     "log-symbols": "^1.0.0",
     "onetime": "^1.0.0",
     "root-hints": "^1.0.0"

--- a/package.json
+++ b/package.json
@@ -44,10 +44,7 @@
     "detect"
   ],
   "dependencies": {
-    "each-async": "^1.1.0",
     "log-symbols": "^1.0.0",
-    "native-dns": "https://github.com/silverwind/node-dns/tarball/8b75198dd8",
-    "onetime": "^1.0.0",
     "root-hints": "^1.0.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,9 @@
     "detect"
   ],
   "dependencies": {
+    "each-async": "^1.1.1",
     "log-symbols": "^1.0.0",
+    "onetime": "^1.0.0",
     "root-hints": "^1.0.0"
   },
   "devDependencies": {

--- a/readme.md
+++ b/readme.md
@@ -67,9 +67,9 @@ $ is-online --help
 
 ## How it works
 
-In node, we contact one of the thirteen [root servers](https://www.iana.org/domains/root/servers) and ask them to direct us to the servers which host the root zone (an empty string query with the type `NS`). If we get an answer containing one or more server, we return online status, any error on this requests leads to an offline status.
+In node, we contact one of the thirteen [root servers](https://www.iana.org/domains/root/servers) and ask them to direct us to the servers which host the root zone (an empty string query with the type `NS`). If we get an answer containing one or more server, we return online status, any error on this requests leads to an offline status. In the rare case where we don't get an acceptable answer a second check is run which tries to connect to a series of popular web sites on port 80. If one of these connects, we return online, otherwise offline status.
 
-In the browser, we use a check which requests an uncached `favicon.ico` on a series of popular websites. If one of this checks succeeds, we return online status. If all the requests fail, we return offline status.
+In the browser, a sophisticated check like in node is not possible because DNS and sockets are abstracted away. We use a check which requests an uncached `favicon.ico` on a series of popular websites. If one of this checks succeeds, we return online status. If all the requests fail, we return offline status.
 
 
 ## Contributors

--- a/readme.md
+++ b/readme.md
@@ -67,9 +67,9 @@ $ is-online --help
 
 ## How it works
 
-In node, we first contact one of the thirteen [root servers](https://www.iana.org/domains/root/servers) and ask them to direct us to the servers which host the `.com` zone. If they answer us, we return an online status, if no answer is given within one second, we return an offline status. In the rare case where an firewall intercepts the packet and answers it on its behalf, a second check is run which tries to connect to a series of popular web sites on port 80. If one of these connects, we return online, otherwise offline status.
+In node, we contact one of the thirteen [root servers](https://www.iana.org/domains/root/servers) and ask them to direct us to the servers which host the root zone (an empty string query with the type `NS`). If we get an answer containing one or more server, we return online status, any error on this requests leads to an offline status.
 
-In the browser, a sophisticated check like in node is not possible because DNS and sockets are abstracted away. We use a check which requests an uncached `favicon.ico` on a series of popular websites. If one of this checks succeeds, we return online status. If all the requests fail, we return offline status.
+In the browser, we use a check which requests an uncached `favicon.ico` on a series of popular websites. If one of this checks succeeds, we return online status. If all the requests fail, we return offline status.
 
 
 ## Contributors


### PR DESCRIPTION
I ended up rewriting the entire thing.

The domain check was causing an issue of the CLI not exiting timely when offline. It was related to sockets keeping the process from exiting. All my attempts with `socket.unref()`, `socket.destroy()`, `socket.end()` failed, so I opted to remove it entirely.

This will fix #6 and #12, let me know how you like it.