### PR TITLE
Close the udp socket instead of unrefing

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,15 +41,18 @@ module.exports = function (cb) {
 			isReachable(hostnames, cb);
 		}
 
-		udpSocket.unref();
+		udpSocket.close();
+		udpSocket = null;
 	});
 
 	udpSocket.send(payload, 0, payload.length, 53, server, function () {
 		setTimeout(function () {
 			// We ran into the timeout, we're offline with high confidence
 			cb(null, false);
-		}, timeout);
 
-		udpSocket.unref();
+			if (udpSocket) {
+				udpSocket.close();
+			}
+		}, timeout);
 	});
 };


### PR DESCRIPTION
Unrefing keeps the socket fd open, essentially causing a fd leak since the
socket is never used again after the unref.