### PR TITLE
Rewrite to use public-ip check

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -1,8 +1,13 @@
 'use strict';
-const isReachable = require('is-reachable');
-const hostnames = require('./hostnames');
+
+const publicIp = require('public-ip');
+
+const defaults = {
+	timeout: 5000,
+	version: 'v4'
+};
 
 module.exports = options => {
-	options = options || {};
-	return isReachable(options.hostnames || hostnames);
+	options = Object.assign({}, defaults, options);
+	return publicIp[options.version](options).then(() => true).catch(() => false);
 };

--- a/hostnames.js
+++ b/hostnames.js
@@ -1,8 +1,0 @@
-'use strict';
-
-module.exports = [
-	'www.google.com',
-	'www.cloudflare.com',
-	'www.baidu.com',
-	'www.yandex.ru'
-];

--- a/package.json
+++ b/package.json
@@ -44,9 +44,10 @@
     "accessible"
   ],
   "dependencies": {
-    "is-reachable": "^2.2.0",
-    "random-item": "^1.0.0",
-    "root-hints": "^1.0.12"
+    "got": "^6.7.1",
+    "p-any": "^1.0.0",
+    "p-timeout": "^1.0.0",
+    "public-ip": "^2.3.0"
   },
   "devDependencies": {
     "ava": "*",

--- a/readme.md
+++ b/readme.md
@@ -44,9 +44,11 @@ Milliseconds to wait for a server to respond.
 ##### version
 
 Type: `string`<br>
+Values: `v4` `v6`<br>
 Default: `v4`
 
-Internet Protocol version to use. This is an advanced option that is usually not neccessary to be set, but it can prove useful to specifically assert IPv6 connectivity. Valid values are either `'v4'` or `'v6'`. Default: `'v4'`.
+Internet Protocol version to use. This is an advanced option that is usually not neccessary to be set, but it can prove useful to specifically assert IPv6 connectivity.
+
 
 ## How it works
 
@@ -56,7 +58,8 @@ The following checks are run in parallel:
 - Query `myip.opendns.com` on OpenDNS (Node.js only)
 - Retrieve Apple's Captive Portal test page (Node.js only)
 
-When the first check suceeds, the returned Promise is resolved to `true`.
+When the first check succeeds, the returned Promise is resolved to `true`.
+
 
 ## Maintainers
 

--- a/readme.md
+++ b/readme.md
@@ -37,25 +37,26 @@ Type: `Object`
 ##### timeout
 
 Type: `number`<br>
-Default: `2000`
+Default: `5000`
 
-Milliseconds to wait for a server to respond. This option is only supported in Node.js.
+Milliseconds to wait for a server to respond.
 
-##### hostnames
+##### version
 
-Type: `string` `Array`<br>
-Default: `['www.google.com', 'www.cloudflare.com', 'www.baidu.com', 'www.yandex.ru']`
+Type: `string`<br>
+Default: `v4`
 
-One or more hosts to check. Can either be a just a `hostname`, a `hostname:port` combination or a full URL like `https://hostname`.
+Internet Protocol version to use. This is an advanced option that is usually not neccessary to be set, but it can prove useful to specifically assert IPv6 connectivity. Valid values are either `'v4'` or `'v6'`. Default: `'v4'`.
 
 ## How it works
 
-In Node.js, we first contact one of the thirteen [root servers](https://www.iana.org/domains/root/servers) and ask them to direct us to the servers which host the `<root>` zone (Which they are themselves). If the server answers, we return an online status.
+The following checks are run in parallel:
 
-If no satisfying answer is given within two seconds, we return an offline status. In the rare case where a firewall intercepts the packet and answers on its behalf, a second check is run which tries to connect to a series of popular web sites on port 80. If one of these connect, we return online, otherwise offline status.
+- Retrieve [icanhazip.com](https://github.com/major/icanhaz) via HTTPS
+- Query `myip.opendns.com` on OpenDNS (Node.js only)
+- Retrieve Apple's Captive Portal test page (Node.js only)
 
-In the browser, a sophisticated check like in Node.js is not possible because DNS and sockets are abstracted away. We use a check which requests an uncached `favicon.ico` on a series of popular websites. If one of these checks succeed, we return online status. If all the requests fail, we return offline status.
-
+When the first check suceeds, the returned Promise is resolved to `true`.
 
 ## Maintainers
 

--- a/test-browser.js
+++ b/test-browser.js
@@ -1,5 +1,5 @@
 // Need to test manually in devtools
-// $ browserify test-browser.js > tmp.js
+// $ browserify test-browser.js | pbcopy
 'use strict';
 const isOnline = require('./browser');
 

--- a/test.js
+++ b/test.js
@@ -1,14 +1,24 @@
 import test from 'ava';
 import m from './';
 
-test('main', async t => {
+test('v4', async t => {
 	t.true(await m());
 });
 
-test('timeout', async t => {
+test('v4 with timeout', async t => {
 	t.true(await m({timeout: 500}));
 });
 
-test('impossible timeout', async t => {
+test('v4 with impossible timeout', async t => {
 	t.false(await m({timeout: 1}));
 });
+
+if (!process.env.CI) {
+	test('v6', async t => {
+		t.true(await m({version: 'v6'}));
+	});
+
+	test('v6 with timeout', async t => {
+		t.true(await m({version: 'v6', timeout: 500}));
+	});
+}


### PR DESCRIPTION
Fixes: https://github.com/sindresorhus/is-online/issues/32
Fixes: https://github.com/sindresorhus/is-online/issues/30
Fixes: https://github.com/sindresorhus/is-online/issues/29
Fixes: https://github.com/sindresorhus/is-online/issues/25
Fixes: https://github.com/sindresorhus/is-online/issues/22
Fixes: https://github.com/sindresorhus/is-online/issues/15

One outstanding issue which I can't quite explain is that browserify somehow includes the `got` dependency instead of the lightweight [`browser.js`](https://github.com/sindresorhus/public-ip/blob/master/browser.js). @sindresorhus any idea why?

```sh
$ browserify browser.js | wc -c
  288046
```