### PR TITLE
add cancellation of outstanding promises

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,8 +50,8 @@ module.exports = options => {
 			return true;
 		}),
 		promises[2].then(() => {
+			promises[0].cancel();
 			promises[1].cancel();
-			promises[2].cancel();
 			return true;
 		})
 	]);

--- a/index.js
+++ b/index.js
@@ -42,17 +42,14 @@ module.exports = options => {
 		promises[0].then(() => {
 			promises[1].cancel();
 			promises[2].cancel();
-			return true;
 		}),
 		promises[1].then(() => {
 			promises[0].cancel();
 			promises[2].cancel();
-			return true;
 		}),
 		promises[2].then(() => {
 			promises[0].cancel();
 			promises[1].cancel();
-			return true;
 		})
 	]);
 

--- a/index.js
+++ b/index.js
@@ -11,20 +11,50 @@ const defaults = {
 };
 
 function appleCheck(options) {
-	return got('http://captive.apple.com/hotspot-detect.html', {
+	const gotPromise = got('http://captive.apple.com/hotspot-detect.html', {
 		family: options.version === 'v4' ? 4 : 6,
 		headers: {'User-Agent': 'CaptiveNetworkSupport/1.0 wispr'}
-	}).then(res => /Success/.test(res.body || '') || Promise.reject());
+	});
+
+	const promise = gotPromise.then(res => {
+		return /Success/.test(res.body || '') || Promise.reject();
+	}).catch(err => {
+		if (!(err instanceof got.CancelError)) {
+			throw err;
+		}
+	});
+
+	promise.cancel = gotPromise.cancel;
+
+	return promise;
 }
 
 module.exports = options => {
 	options = Object.assign({}, defaults, options);
 
-	const p = pAny([
-		publicIp[options.version]().then(() => true),
-		publicIp[options.version]({https: true}).then(() => true),
+	const promises = [
+		publicIp[options.version](),
+		publicIp[options.version]({https: true}),
 		appleCheck(options)
+	];
+
+	const p = pAny([
+		promises[0].then(() => {
+			promises[1].cancel();
+			promises[2].cancel();
+			return true;
+		}),
+		promises[1].then(() => {
+			promises[0].cancel();
+			promises[2].cancel();
+			return true;
+		}),
+		promises[2].then(() => {
+			promises[1].cancel();
+			promises[2].cancel();
+			return true;
+		})
 	]);
 
-	return pTimeout(p, options.timeout).catch(() => false);
+	return pTimeout(p, options.timeout).then(() => true).catch(() => false);
 };


### PR DESCRIPTION
This turned out rather unelegant because there's apparantly no clean way of checking if a `Promise` has resolved (see https://stackoverflow.com/q/30564053).