### PR TITLE
Exit early if non-internal network adapter doesn't exist

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,7 +45,7 @@ const isOnline = options => {
 	if (flat(Object.values(os.networkInterfaces())).every(({internal}) => internal)) {
 		return false;
 	}
-	
+
 	const queries = [];
 
 	const promise = pAny([

--- a/index.js
+++ b/index.js
@@ -1,8 +1,12 @@
 'use strict';
+const os = require('os');
 const got = require('got');
 const publicIp = require('public-ip');
 const pAny = require('p-any');
 const pTimeout = require('p-timeout');
+
+// Use Array#flat when targeting Node.js 12
+const flat = array => [].concat(...array);
 
 const appleCheck = options => {
 	const gotPromise = got('https://captive.apple.com/hotspot-detect.html', {
@@ -38,6 +42,10 @@ const isOnline = options => {
 		...options
 	};
 
+	if (flat(Object.values(os.networkInterfaces())).some(({internal}) => !internal)) {
+		return false;
+	}
+	
 	const queries = [];
 
 	const promise = pAny([

--- a/index.js
+++ b/index.js
@@ -42,7 +42,7 @@ const isOnline = options => {
 		...options
 	};
 
-	if (flat(Object.values(os.networkInterfaces())).some(({internal}) => !internal)) {
+	if (flat(Object.values(os.networkInterfaces())).every(({internal}) => internal)) {
 		return false;
 	}
 	


### PR DESCRIPTION
Fixes: #75

// @sindresorhus 