### PR TITLE
Rename `version` option to `ipVersion` and make it a number

### DIFF
--- a/browser.js
+++ b/browser.js
@@ -4,12 +4,14 @@ const publicIp = require('public-ip');
 const isOnline = async options => {
 	options = {
 		timeout: 5000,
-		version: 'v4',
+		ipVersion: 4,
 		...options
 	};
 
+	const publicIpFunctionName = options.ipVersion === 4 ? 'v4' : 'v6';
+
 	try {
-		await publicIp[options.version](options);
+		await publicIp[publicIpFunctionName](options);
 		return true;
 	} catch (_) {
 		return false;

--- a/browser.js
+++ b/browser.js
@@ -13,7 +13,7 @@ const isOnline = async options => {
 		return false;
 	}
 
-  const publicIpFunctionName = options.ipVersion === 4 ? 'v4' : 'v6';
+	const publicIpFunctionName = options.ipVersion === 4 ? 'v4' : 'v6';
 
 	try {
 		await publicIp[publicIpFunctionName](options);

--- a/index.d.ts
+++ b/index.d.ts
@@ -10,9 +10,9 @@ declare namespace isOnline {
 		/**
 		Internet Protocol version to use. This is an advanced option that is usually not necessary to be set, but it can prove useful to specifically assert IPv6 connectivity.
 
-		@default 'v4'
+		@default 4
 		*/
-		readonly version?: 'v4' | 'v6';
+		readonly ipVersion?: 4 | 6;
 	}
 }
 

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const pTimeout = require('p-timeout');
 const appleCheck = options => {
 	const gotPromise = got('http://captive.apple.com/hotspot-detect.html', {
 		timeout: options.timeout,
-		family: options.version === 'v4' ? 4 : 6,
+		family: options.ipVersion,
 		headers: {
 			'user-agent': 'CaptiveNetworkSupport/1.0 wispr'
 		}
@@ -34,21 +34,27 @@ const appleCheck = options => {
 const isOnline = options => {
 	options = {
 		timeout: 5000,
-		version: 'v4',
+		ipVersion: 4,
 		...options
 	};
+
+	if (![4, 6].includes(options.ipVersion)) {
+		throw new TypeError('`ipVersion` must be 4 or 6');
+	}
+
+	const publicIpFunctionName = options.ipVersion === 4 ? 'v4' : 'v6';
 
 	const queries = [];
 
 	const promise = pAny([
 		(async () => {
-			const query = publicIp[options.version](options);
+			const query = publicIp[publicIpFunctionName](options);
 			queries.push(query);
 			await query;
 			return true;
 		})(),
 		(async () => {
-			const query = publicIp[options.version]({...options, onlyHttps: true});
+			const query = publicIp[publicIpFunctionName]({...options, onlyHttps: true});
 			queries.push(query);
 			await query;
 			return true;

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -3,5 +3,5 @@ import isOnline = require('.');
 
 expectType<Promise<boolean>>(isOnline());
 expectType<Promise<boolean>>(isOnline({timeout: 10}));
-expectType<Promise<boolean>>(isOnline({version: 'v4'}));
-expectType<Promise<boolean>>(isOnline({version: 'v6'}));
+expectType<Promise<boolean>>(isOnline({ipVersion: 4}));
+expectType<Promise<boolean>>(isOnline({ipVersion: 6}));

--- a/readme.md
+++ b/readme.md
@@ -41,11 +41,11 @@ Default: `5000`
 
 Milliseconds to wait for a server to respond.
 
-##### version
+##### ipVersion
 
-Type: `string`\
-Values: `'v4'` `'v6'`\
-Default: `'v4'`
+Type: `number`\
+Values: `4` `6`\
+Default: `4`
 
 Internet Protocol version to use. This is an advanced option that is usually not necessary to be set, but it can prove useful to specifically assert IPv6 connectivity.
 

--- a/readme.md
+++ b/readme.md
@@ -41,7 +41,7 @@ Milliseconds to wait for a server to respond.
 ##### ipVersion
 
 Type: `number`\
-Values: `4` `6`\
+Values: `4 | 6`\
 Default: `4`
 
 Internet Protocol version to use. This is an advanced option that is usually not necessary to be set, but it can prove useful to specifically assert IPv6 connectivity.

--- a/test.js
+++ b/test.js
@@ -15,10 +15,10 @@ test('v4 with impossible timeout', async t => {
 
 if (!process.env.CI) {
 	test('v6', async t => {
-		t.true(await isOnline({version: 'v6'}));
+		t.true(await isOnline({ipVersion: 6}));
 	});
 
 	test('v6 with timeout', async t => {
-		t.true(await isOnline({version: 'v6', timeout: 500}));
+		t.true(await isOnline({ipVersion: 6, timeout: 500}));
 	});
 }


### PR DESCRIPTION
I think it's best to merge this now and wait for other changes before publishing this along with the removal of `.default`.

Fixes: #59 